### PR TITLE
Розмір соціальних іконок в футері

### DIFF
--- a/src/css/footer.css
+++ b/src/css/footer.css
@@ -115,3 +115,9 @@ policy-link {
 .footer-top {
   margin-bottom: 40px;
 }
+
+
+.footer-icon-item-link {
+
+  width: 40px;
+  height: 40px;


### PR DESCRIPTION
Для десктопа и планшета увеличены рамки вокруг иконок. Вместо 32 стало 40